### PR TITLE
RGB to xy first divide by 255.

### DIFF
--- a/rgbxy/__init__.py
+++ b/rgbxy/__init__.py
@@ -147,9 +147,13 @@ class ColorHelper:
         dy = one.y - two.y
         return math.sqrt(dx * dx + dy * dy)
 
-    def get_xy_point_from_rgb(self, red, green, blue):
+    def get_xy_point_from_rgb(self, red_i, green_i, blue_i):
         """Returns an XYPoint object containing the closest available CIE 1931 x, y coordinates
         based on the RGB input values."""
+
+        red = red_i / 255.0
+        green = green_i / 255.0
+        blue = blue_i / 255.0
 
         r = ((red + 0.055) / (1.0 + 0.055))**2.4 if (red > 0.04045) else (red / 12.92)
         g = ((green + 0.055) / (1.0 + 0.055))**2.4 if (green > 0.04045) else (green / 12.92)


### PR DESCRIPTION
In the conversion from RGB to xy you schould first devide the integer by 255.
This is stated in the philips hue conversion method https://developers.meethue.com/develop/application-design-guidance/color-conversion-formulas-rgb-to-xy-and-back/
"1. Get the RGB values from your color object and convert them to be between 0 and 1. So the RGB color (255, 0, 100) becomes (1.0, 0.0, 0.39)"