### PR TITLE
Added type annotations

### DIFF
--- a/rgbxy/__init__.py
+++ b/rgbxy/__init__.py
@@ -7,36 +7,40 @@ Copyright (c) 2016 Benjamin Knight / MIT License.
 """
 import math
 import random
-from collections import namedtuple
+from typing import NamedTuple
 
 __version__ = '0.5.1'
 
 # Represents a CIE 1931 XY coordinate pair.
-XYPoint = namedtuple('XYPoint', ['x', 'y'])
+class XYPoint(NamedTuple):
+    x: float
+    y: float
+
+Gamut = tuple[XYPoint, XYPoint, XYPoint]
 
 # Legacy lights - LivingColors Iris, Bloom, Aura, LightStrips
-GamutA = (
+GamutA: Gamut = (
     XYPoint(0.704, 0.296),
     XYPoint(0.2151, 0.7106),
     XYPoint(0.138, 0.08),
 )
 
 # Older model Hue lights - older A19 bulbs etc.
-GamutB = (
+GamutB: Gamut = (
     XYPoint(0.675, 0.322),
     XYPoint(0.4091, 0.518),
     XYPoint(0.167, 0.04),
 )
 
 # All newer model Hue lights - BR30, A19 (Gen 3), Go, LightStrips plus
-GamutC = (
+GamutC: Gamut = (
     XYPoint(0.692, 0.308),
     XYPoint(0.17, 0.7),
     XYPoint(0.153, 0.048),
 )
 
 
-def get_light_gamut(modelId):
+def get_light_gamut(modelId: str) -> Gamut:
     """Gets the correct color gamut for the provided model id.
     Docs: https://developers.meethue.com/develop/hue-api/supported-devices/
           'NOTE: The supported light table will not be maintained due to the large expansion 
@@ -56,41 +60,41 @@ def get_light_gamut(modelId):
 
 class ColorHelper:
 
-    def __init__(self, gamut=GamutB):
+    def __init__(self, gamut: Gamut = GamutB) -> None:
         self.Red = gamut[0]
         self.Lime = gamut[1]
         self.Blue = gamut[2]
 
-    def hex_to_red(self, hex):
+    def hex_to_red(self, hex: str) -> int:
         """Parses a valid hex color string and returns the Red RGB integer value."""
         return int(hex[0:2], 16)
 
-    def hex_to_green(self, hex):
+    def hex_to_green(self, hex: str) -> int:
         """Parses a valid hex color string and returns the Green RGB integer value."""
         return int(hex[2:4], 16)
 
-    def hex_to_blue(self, hex):
+    def hex_to_blue(self, hex: str) -> int:
         """Parses a valid hex color string and returns the Blue RGB integer value."""
         return int(hex[4:6], 16)
 
-    def hex_to_rgb(self, h):
+    def hex_to_rgb(self, h: str) -> tuple[int, int, int]:
         """Converts a valid hex color string to an RGB array."""
         rgb = (self.hex_to_red(h), self.hex_to_green(h), self.hex_to_blue(h))
         return rgb
 
-    def rgb_to_hex(self, r, g, b):
+    def rgb_to_hex(self, r: int, g: int, b: int) -> str:
         """Converts RGB to hex."""
         return '%02x%02x%02x' % (r, g, b)
 
-    def random_rgb_value(self):
+    def random_rgb_value(self) -> int:
         """Return a random Integer in the range of 0 to 255, representing an RGB color value."""
         return random.randrange(0, 256)
 
-    def cross_product(self, p1, p2):
+    def cross_product(self, p1: XYPoint, p2: XYPoint) -> float:
         """Returns the cross product of two XYPoints."""
         return (p1.x * p2.y - p1.y * p2.x)
 
-    def check_point_in_lamps_reach(self, p):
+    def check_point_in_lamps_reach(self, p: XYPoint) -> bool:
         """Check if the provided XYPoint can be recreated by a Hue lamp."""
         v1 = XYPoint(self.Lime.x - self.Red.x, self.Lime.y - self.Red.y)
         v2 = XYPoint(self.Blue.x - self.Red.x, self.Blue.y - self.Red.y)
@@ -101,7 +105,7 @@ class ColorHelper:
 
         return (s >= 0.0) and (t >= 0.0) and (s + t <= 1.0)
 
-    def get_closest_point_to_line(self, A, B, P):
+    def get_closest_point_to_line(self, A: XYPoint, B: XYPoint, P: XYPoint) -> XYPoint:
         """Find the closest point on a line. This point will be reproducible by a Hue lamp."""
         AP = XYPoint(P.x - A.x, P.y - A.y)
         AB = XYPoint(B.x - A.x, B.y - A.y)
@@ -116,7 +120,7 @@ class ColorHelper:
 
         return XYPoint(A.x + AB.x * t, A.y + AB.y * t)
 
-    def get_closest_point_to_point(self, xy_point):
+    def get_closest_point_to_point(self, xy_point: XYPoint) -> XYPoint:
         # Color is unreproducible, find the closest point on each line in the CIE 1931 'triangle'.
         pAB = self.get_closest_point_to_line(self.Red, self.Lime, xy_point)
         pAC = self.get_closest_point_to_line(self.Blue, self.Red, xy_point)
@@ -144,13 +148,13 @@ class ColorHelper:
 
         return XYPoint(cx, cy)
 
-    def get_distance_between_two_points(self, one, two):
+    def get_distance_between_two_points(self, one: XYPoint, two: XYPoint) -> float:
         """Returns the distance between two XYPoints."""
         dx = one.x - two.x
         dy = one.y - two.y
         return math.sqrt(dx * dx + dy * dy)
 
-    def get_xy_point_from_rgb(self, red_i, green_i, blue_i):
+    def get_xy_point_from_rgb(self, red_i: int, green_i: int, blue_i: int) -> XYPoint:
         """Returns an XYPoint object containing the closest available CIE 1931 x, y coordinates
         based on the RGB input values."""
 
@@ -178,7 +182,7 @@ class ColorHelper:
 
         return xy_point
 
-    def get_rgb_from_xy_and_brightness(self, x, y, bri=1):
+    def get_rgb_from_xy_and_brightness(self, x: float, y: float, bri: float = 1) -> tuple[int, int, int]:
         """Inverse of `get_xy_point_from_rgb`. Returns (r, g, b) for given x, y values.
         Implementation of the instructions found on the Philips Hue iOS SDK docs: http://goo.gl/kWKXKl
         """
@@ -225,36 +229,36 @@ class ColorHelper:
 
 class Converter:
 
-    def __init__(self, gamut=GamutB):
+    def __init__(self, gamut: Gamut = GamutB) -> None:
         self.color = ColorHelper(gamut)
 
-    def hex_to_xy(self, h):
+    def hex_to_xy(self, h: str) -> tuple[float, float]:
         """Converts hexadecimal colors represented as a String to approximate CIE
         1931 x and y coordinates.
         """
         rgb = self.color.hex_to_rgb(h)
         return self.rgb_to_xy(rgb[0], rgb[1], rgb[2])
 
-    def rgb_to_xy(self, red, green, blue):
+    def rgb_to_xy(self, red: int, green: int, blue: int) -> tuple[float, float]:
         """Converts red, green and blue integer values to approximate CIE 1931
         x and y coordinates.
         """
         point = self.color.get_xy_point_from_rgb(red, green, blue)
         return (point.x, point.y)
 
-    def xy_to_hex(self, x, y, bri=1):
+    def xy_to_hex(self, x: float, y: float, bri: float = 1) -> str:
         """Converts CIE 1931 x and y coordinates and brightness value from 0 to 1
         to a CSS hex color."""
         r, g, b = self.color.get_rgb_from_xy_and_brightness(x, y, bri)
         return self.color.rgb_to_hex(r, g, b)
 
-    def xy_to_rgb(self, x, y, bri=1):
+    def xy_to_rgb(self, x: float, y: float, bri: float = 1) -> tuple[int, int, int]:
         """Converts CIE 1931 x and y coordinates and brightness value from 0 to 1
         to a CSS hex color."""
         r, g, b = self.color.get_rgb_from_xy_and_brightness(x, y, bri)
         return (r, g, b)
 
-    def get_random_xy_color(self):
+    def get_random_xy_color(self) -> tuple[float, float]:
         """Returns the approximate CIE 1931 x,y coordinates of a random color."""
         r = self.color.random_rgb_value()
         g = self.color.random_rgb_value()


### PR DESCRIPTION
The type annotations used are compatible with Python 3.9 and newer.
If desired, small annotation changes would allow compatibility back to Python 3.5.